### PR TITLE
Add fluidvids for responsive iframes

### DIFF
--- a/Resources/public/fluidvids/fluidvids.js
+++ b/Resources/public/fluidvids/fluidvids.js
@@ -25,7 +25,7 @@
 		/*
 	     * RegExp, extend this if you need more players
 	     */
-		players = /www.youtube.com|player.vimeo.com/;
+		players = /www.youtube.com|player.vimeo.com|slideshare.net/;
 
 		/*
 		 * If the RegExp pattern exists within the current iframe


### PR DESCRIPTION
Added fluidvids.js (https://github.com/toddmotto/fluidvids) because the non responsive iframes on the Claroline homepage a driving me mad.
