### PR TITLE
Correct z-index property on datepicker while called on a modal

### DIFF
--- a/Resources/public/jquery/plugin/datepicker/js/bootstrap-datepicker.js
+++ b/Resources/public/jquery/plugin/datepicker/js/bootstrap-datepicker.js
@@ -419,7 +419,8 @@
 				scrollTop = $window.scrollTop();
 
 			var zIndex = parseInt(this.element.parents().filter(function() {
-							return $(this).css('z-index') != 'auto';
+							var zIndex = $(this).css('z-index');
+                            return zIndex != 'auto' && zIndex != '0';
 						}).first().css('z-index'))+10;
 			var offset = this.component ? this.component.parent().offset() : this.element.offset();
 			var height = this.component ? this.component.outerHeight(true) : this.element.outerHeight(false);


### PR DESCRIPTION
Add patch for fixing eternicode/bootstrap-datepicker#609 as this patch was not merged on the lib for a while.
